### PR TITLE
Improve README lifecycle documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,64 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# MMC Backend
 
-# 项目目录
+MMC Backend 是基于 **NestJS** 构建的云原生后端，主要服务于英语学习平台。项目采用 AWS Lambda + API Gateway 的无服务器架构，并集成 OpenAI、OpenRouter 及 Upstash Vector 等服务，提供 AI 故事生成、RAG 知识库、音频与图像管理以及用户认证等功能。
+
+## 目录结构概览
+```
 src/
-├── app.controller.spec.ts
-├── app.controller.ts
-├── app.module.ts
-├── app.service.ts
-├── common
-│   ├── decorators
-│   ├── filters
-│   ├── guards
-│   └── interfaces
-├── config
-├── main.ts
-└── modules
+├── main.ts                # 本地开发入口
+├── lambda.ts              # 部署到 Lambda 的入口
+├── modules/               # 业务模块
+│   ├── ai/                # AI 故事与聊天接口
+│   ├── auth/              # Cognito 认证
+│   ├── audio/             # 音频管理
+│   ├── image/             # 图像管理
+│   ├── rag/               # RAG 服务
+│   └── health/            # 健康检查
+infrastructure/            # AWS CDK 基础设施代码
+```
 
-# 开发流程
-> 本地开发时使用 main.ts 作为入口，连接开发环境的 AWS 资源
-> Lambda 部署时使用 lambda.ts 作为入口，使用对应环境的 AWS 资源
-> 环境变量会正确注入到 Lambda 中
-> 开发环境和生产环境完全隔离
+## 开发流程
+1. **安装依赖**
+   ```bash
+   yarn install
+   ```
+2. **配置环境变量**
+   ```bash
+   cp environment-example.txt .env.development
+   # 根据需要创建 .env.test 或 .env.production
+   ```
+   编辑 `.env.*` 文件，填入 `OPENROUTER_API_KEY`、`OPENAI_API_KEY` 等密钥。
+3. **部署开发资源并启动本地服务**
+   ```bash
+   yarn run deploy:dev:script      # 构建 Lambda Layer 和函数并部署到 dev
+   yarn start:dev                  # 使用 main.ts 启动本地服务器
+   ```
 
-## 环境变量配置
-在部署前，需要正确配置环境变量。项目根目录下提供了`environment-example.txt`文件作为参考。
+## 部署到测试环境
+测试环境可使用与开发环境相同的脚本，但需将 `NODE_ENV` 设为 `test` 并准备 `.env.test`：
+```bash
+cp environment-example.txt .env.test
+NODE_ENV=test yarn run deploy:dev    # 使用默认脚本时请先执行 `yarn build:layer`
+# 或直接运行下列脚本自动完成构建和部署
+# NODE_ENV=test yarn run deploy:dev:script
+```
+部署完成后即可在测试环境验证功能。
 
-1. 创建环境配置文件：
-```shell
-# 开发环境配置
-cp environment-example.txt .env.development
-# 生产环境配置
+## 部署到生产环境
+生产环境使用独立的配置文件和脚本：
+```bash
 cp environment-example.txt .env.production
+yarn run deploy:prod:script
 ```
+该脚本会自动构建 Lambda 层和函数，并通过 AWS CDK 部署所有资源。
 
-2. 编辑配置文件，填入相应的API密钥：
-```shell
-# 使用你喜欢的编辑器
-nano .env.development
-# 或
-vim .env.production
-```
-
-3. 确保以下关键环境变量已设置：
-   - `OPENROUTER_API_KEY` - 用于Storytelling功能
-   - `OPENAI_API_KEY` - 用于RAG功能和向量嵌入
-
-## 开发环境
-```shell
-# 使用新的部署脚本（推荐）
-pnpm run deploy:dev:script
-
-# 或者使用传统方式
-# 先部署开发环境的 AWS 资源
-pnpm run deploy:dev
-
-# 本地运行开发服务器（使用 main.ts 作为入口）
-pnpm start:dev
-```
-
-## 线上环境
-```shell
-# 使用新的部署脚本（推荐）
-pnpm run deploy:prod:script
-
-# 或者使用传统方式
-# 部署生产环境的 AWS 资源
-pnpm run deploy:prod
-```
-
-## 设置管理员账户
-```shell
+## 管理员账户设置
+部署完成后，可通过 AWS CLI 将用户加入管理员组：
+```bash
 aws cognito-idp admin-add-user-to-group \
   --user-pool-id YOUR_USER_POOL_ID \
   --username USER_EMAIL \
   --group-name admin
-```****
+```
+
+更多环境变量说明参见 [docs/environment-setup.md](docs/environment-setup.md)。


### PR DESCRIPTION
## Summary
- rewrite README with project overview and feature list
- add sections covering dev/test/prod lifecycle and admin setup
- clarify Lambda layer build steps

## Testing
- `yarn install` *(fails: onnxruntime-node couldn't be built)*
- `yarn test` *(fails to compile due to missing Jest globals)*

------
https://chatgpt.com/codex/tasks/task_e_6883304935648326bbedfb1fb87ed1df